### PR TITLE
Adding sparse trsm to the public API (#127)

### DIFF
--- a/RandBLAS/sparse_data/base.hh
+++ b/RandBLAS/sparse_data/base.hh
@@ -32,6 +32,7 @@
 #include "RandBLAS/base.hh"
 #include <blas.hh>
 #include <concepts>
+#include <iostream>
 
 
 namespace RandBLAS::sparse_data {
@@ -89,6 +90,21 @@ static inline void sorted_nonzero_locations_to_pointer_array(
     delete [] temp;
     return;
 }
+
+
+template <SignedInteger sint_t>
+static bool compressed_indices_are_increasing(int64_t num_vecs, sint_t *ptrs, sint_t *idxs, int64_t *failed_ind = nullptr) {
+    for (int64_t i = 0; i < num_vecs; ++i) {
+        for (int64_t j = ptrs[i]; j < ptrs[i+1]-1; ++j) {
+            if (idxs[j+1] <= idxs[j]) {
+                if (failed_ind != nullptr) *failed_ind = j;
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 
 // Idea: change all "const" attributes to for SpMatrix to return values from inlined functions. 
 // Looks like there'd be no collision with function/property names for sparse matrix

--- a/RandBLAS/sparse_data/conversions.hh
+++ b/RandBLAS/sparse_data/conversions.hh
@@ -62,7 +62,7 @@ void coo_to_csc(COOMatrix<T, sint_t1> &coo, CSCMatrix<T, sint_t2> &csc) {
 }
 
 template <typename T, SignedInteger sint_t1 = int64_t, SignedInteger sint_t2 = int64_t>
-void csc_to_coo(CSCMatrix<T, sint_t1> &csc, COOMatrix<T, sint_t2> &coo) {
+void csc_to_coo(const CSCMatrix<T, sint_t1> &csc, COOMatrix<T, sint_t2> &coo) {
     randblas_require(csc.n_rows == coo.n_rows);
     randblas_require(csc.n_cols == coo.n_cols);
     randblas_require(csc.index_base == IndexBase::Zero);
@@ -103,7 +103,7 @@ void coo_to_csr(COOMatrix<T, sint_t1> &coo, CSRMatrix<T, sint_t2> &csr) {
 }
 
 template <typename T, SignedInteger sint_t1 = int64_t, SignedInteger sint_t2 = int64_t>
-void csr_to_coo(CSRMatrix<T, sint_t1> &csr, COOMatrix<T, sint_t2> &coo) {
+void csr_to_coo(const CSRMatrix<T, sint_t1> &csr, COOMatrix<T, sint_t2> &coo) {
     randblas_require(csr.n_rows == coo.n_rows);
     randblas_require(csr.n_cols == coo.n_cols);
     randblas_require(csr.index_base == IndexBase::Zero);
@@ -123,7 +123,7 @@ void csr_to_coo(CSRMatrix<T, sint_t1> &csr, COOMatrix<T, sint_t2> &coo) {
 }
 
 template <typename T, SignedInteger sint_t>
-CSRMatrix<T, sint_t> transpose_as_csr(CSCMatrix<T, sint_t> &A, bool share_memory = true) {
+CSRMatrix<T, sint_t> transpose_as_csr(const CSCMatrix<T, sint_t> &A, bool share_memory = true) {
     if (share_memory) {
         CSRMatrix<T, sint_t> At(A.n_cols, A.n_rows, A.nnz, A.vals, A.colptr, A.rowidxs, A.index_base);
         return At;
@@ -142,7 +142,7 @@ CSRMatrix<T, sint_t> transpose_as_csr(CSCMatrix<T, sint_t> &A, bool share_memory
 }
 
 template <typename T, SignedInteger sint_t>
-CSCMatrix<T, sint_t> transpose_as_csc(CSRMatrix<T, sint_t> &A, bool share_memory = true) {
+CSCMatrix<T, sint_t> transpose_as_csc(const CSRMatrix<T, sint_t> &A, bool share_memory = true) {
     if (share_memory) {
         CSCMatrix<T, sint_t> At(A.n_cols, A.n_rows, A.nnz, A.vals, A.colidxs, A.rowptr, A.index_base);
         return At;

--- a/RandBLAS/sparse_data/coo_matrix.hh
+++ b/RandBLAS/sparse_data/coo_matrix.hh
@@ -282,11 +282,9 @@ void reserve_coo(int64_t nnz, COOMatrix<T,sint_t> &M) {
     randblas_require(M.rows == nullptr);
     randblas_require(M.cols == nullptr);
     M.nnz = nnz;
-    if (M.nnz > 0) {
-        M.vals = new T[nnz];
-        M.rows = new sint_t[nnz];
-        M.cols = new sint_t[nnz];
-    }
+    M.vals = new T[nnz];
+    M.rows = new sint_t[nnz];
+    M.cols = new sint_t[nnz];
     return;
 }
 

--- a/RandBLAS/sparse_data/csc_matrix.hh
+++ b/RandBLAS/sparse_data/csc_matrix.hh
@@ -58,7 +58,7 @@ struct CSCMatrix {
     using scalar_t = T;
 
     // ------------------------------------------------------------------------
-    /// Signed integer type used in the rowptr and colidxs array members.
+    /// Signed integer type used in the rowidxs and colptr array members.
     using index_t = sint_t; 
 
     // ------------------------------------------------------------------------
@@ -84,7 +84,7 @@ struct CSCMatrix {
     int64_t nnz;
     
     // ------------------------------------------------------------------------
-    ///  A flag to indicate whether colidxs is interpreted
+    ///  A flag to indicate whether rowidxs is interpreted
     ///  with zero-based or one-based indexing.
     ///
     IndexBase index_base;
@@ -200,10 +200,8 @@ void reserve_csc(int64_t nnz, CSCMatrix<T,sint_t> &M) {
     if (M.colptr == nullptr)
         M.colptr = new sint_t[M.n_cols + 1]{0};
     M.nnz = nnz;
-    if (nnz > 0) {
-        M.rowidxs = new sint_t[nnz]{0};
-        M.vals    = new T[nnz]{0.0};
-    }
+    M.rowidxs = new sint_t[nnz]{0};
+    M.vals    = new T[nnz]{0.0};
     return;
 }
 

--- a/RandBLAS/sparse_data/csc_spmm_impl.hh
+++ b/RandBLAS/sparse_data/csc_spmm_impl.hh
@@ -46,8 +46,8 @@ template <typename T, SignedInteger sint_t = int64_t>
 static void apply_csc_to_vector_from_left_ki(
     // CSC-format data
     const T *vals,
-    sint_t *rowidxs,
-    sint_t *colptr,
+    const sint_t *rowidxs,
+    const sint_t *colptr,
     // input-output vector data
     int64_t len_v,
     const T *v,
@@ -71,7 +71,7 @@ static void apply_regular_csc_to_vector_from_left_ki(
     // data for "regular CSC": CSC with fixed nnz per col,
     // which obviates the requirement for colptr.
     const T *vals,
-    sint_t *rowidxs,
+    const sint_t *rowidxs,
     int64_t col_nnz,
     // input-output vector data
     int64_t len_v,
@@ -97,7 +97,7 @@ static void apply_csc_left_jki_p11(
     int64_t d,
     int64_t n,
     int64_t m,
-    CSCMatrix<T, sint_t> &A,
+    const CSCMatrix<T, sint_t> &A,
     const T *B,
     int64_t ldb,
     T *C,
@@ -160,7 +160,7 @@ static void apply_csc_left_kib_rowmajor_1p1(
     int64_t d,
     int64_t n,
     int64_t m,
-    CSCMatrix<T, sint_t> &A,
+    const CSCMatrix<T, sint_t> &A,
     const T *B,
     int64_t ldb,
     T *C,

--- a/RandBLAS/sparse_data/csr_matrix.hh
+++ b/RandBLAS/sparse_data/csr_matrix.hh
@@ -206,10 +206,8 @@ void reserve_csr(int64_t nnz, CSRMatrix<T, sint_t> &M) {
     if (M.rowptr == nullptr) 
         M.rowptr = new sint_t[M.n_rows + 1]{0};
     M.nnz = nnz;
-    if (nnz > 0) {
-        M.colidxs = new sint_t[nnz]{0};
-        M.vals    = new T[nnz]{0.0};
-    }
+    M.colidxs = new sint_t[nnz]{0};
+    M.vals    = new T[nnz]{0.0};
    return;
 }
 

--- a/RandBLAS/sparse_data/csr_spmm_impl.hh
+++ b/RandBLAS/sparse_data/csr_spmm_impl.hh
@@ -48,8 +48,8 @@ template <typename T, SignedInteger sint_t = int64_t>
 static void apply_csr_to_vector_from_left_ik(
     // CSR-format data
     const T *vals,
-    sint_t *rowptr,
-    sint_t *colidxs,
+    const sint_t *rowptr,
+    const sint_t *colidxs,
     // input-output vector data
     const T *v,
     int64_t incv,   // stride between elements of v
@@ -76,7 +76,7 @@ static void apply_csr_left_jik_p11(
     int64_t d,
     int64_t n,
     int64_t m,
-    CSRMatrix<T, sint_t> &A,
+    const CSRMatrix<T, sint_t> &A,
     const T *B,
     int64_t ldb,
     T *C,
@@ -127,7 +127,7 @@ static void apply_csr_left_ikb_rowmajor(
     int64_t d,
     int64_t n,
     int64_t m,
-    CSRMatrix<T, sint_t> &A,
+    const CSRMatrix<T, sint_t> &A,
     const T *B,
     int64_t ldb,
     T *C,

--- a/RandBLAS/sparse_data/spmm_dispatch.hh
+++ b/RandBLAS/sparse_data/spmm_dispatch.hh
@@ -208,13 +208,13 @@ namespace RandBLAS {
 ///     int64_t n, int64_t k, T alpha, SpMat &A, const T *B, int64_t ldb, T beta, T *C, int64_t ldc
 /// ) 
 /// @verbatim embed:rst:leading-slashes
-/// Perform an SPMM-like operation, multiplying a dense matrix on the left with a sparse matrix:
+/// Multiply a dense matrix on the left with a sparse matrix:
 ///
 /// .. math::
 ///     \mat(C) = \alpha \cdot \underbrace{\op(\mtxA)}_{m \times k} \cdot \underbrace{\op(\mat(B))}_{k \times n} + \beta \cdot \underbrace{\mat(C)}_{m \times n},    \tag{$\star$}
 ///
 /// where :math:`\alpha` and :math:`\beta` are real scalars, :math:`\op(\mtxX)` either returns a matrix :math:`\mtxX`
-/// or its transpose, and :math:`\mtxA` is a sparse matrix.
+/// or its transpose, and :math:`\mtxA` is sparse.
 ///
 /// .. dropdown:: Full parameter descriptions
 ///     :animate: fade-in-slide-down
@@ -287,13 +287,13 @@ inline void spmm(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int
 ///     int64_t n, int64_t k, T alpha, const T* A, int64_t lda, SpMat &B, T beta, T *C, int64_t ldc
 /// ) 
 /// @verbatim embed:rst:leading-slashes
-/// Perform an SPMM-like operation, multiplying a dense matrix on the right with a (submatrix of a) sparse matrix:
+/// Multiply a dense matrix on the right with a sparse matrix:
 ///
 /// .. math::
 ///     \mat(C) = \alpha \cdot \underbrace{\op(\mat(A))}_{m \times k} \cdot \underbrace{\op(\mtxB)}_{k \times n} + \beta \cdot \underbrace{\mat(C)}_{m \times n},    \tag{$\star$}
 ///
 /// where :math:`\alpha` and :math:`\beta` are real scalars, :math:`\op(\mtxX)` either returns a matrix :math:`\mtxX`
-/// or its transpose, and :math:`\mtxB` is a sparse matrix.
+/// or its transpose, and :math:`\mtxB` is sparse.
 ///
 /// .. dropdown:: Full parameter descriptions
 ///     :animate: fade-in-slide-down

--- a/RandBLAS/sparse_data/trsm_dispatch.hh
+++ b/RandBLAS/sparse_data/trsm_dispatch.hh
@@ -1,0 +1,221 @@
+// Copyright, 2025. See LICENSE for copyright holder information.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// (1) Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// (2) Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// (3) Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//
+
+#pragma once
+
+#include "RandBLAS/base.hh"
+#include "RandBLAS/exceptions.hh"
+#include "RandBLAS/sparse_data/base.hh"
+#include "RandBLAS/sparse_data/coo_matrix.hh"
+#include "RandBLAS/sparse_data/csr_matrix.hh"
+#include "RandBLAS/sparse_data/csc_matrix.hh"
+#include "RandBLAS/sparse_data/conversions.hh"
+#include "RandBLAS/sparse_data/csc_trsm_impl.hh"
+#include "RandBLAS/sparse_data/csr_trsm_impl.hh"
+#include <vector>
+#include <algorithm>
+
+
+namespace RandBLAS::sparse_data {
+
+
+// We call these functions "TRSM" instead of "SPTRSM" because they're in the sparse_data namespace.
+
+
+template <SparseMatrix SpMat>
+inline void trsm_matrix_validation( const SpMat &A, blas::Uplo uplo, blas::Diag diag, int mode ) {
+    using T = typename SpMat::scalar_t;
+    using sint_t = typename SpMat::index_t;
+    constexpr bool is_csr = std::is_same_v<SpMat, CSRMatrix<T, sint_t>>;
+    int64_t p, ell;
+    
+    const T* vals = A.vals;
+    int64_t m = A.n_rows;
+    int64_t flag = -1;
+    const bool unitdiag = diag == blas::Diag::Unit;
+    if constexpr (is_csr) {
+        const sint_t* ptrs = A.rowptr;
+        const sint_t* idxs = A.colidxs;
+        if (mode >= 0) {
+            bool ordered_indices = compressed_indices_are_increasing(m, ptrs, idxs, &flag);
+            if (!ordered_indices) {
+                std::stringstream ss;
+                ss << "Ill-formed CSR matrix; indices in row " << flag << " are not sorted.";
+                throw RandBLAS::Error(ss.str());
+            }
+        }
+        for (ell = 0; ell < m; ++ell) {
+            p = (uplo == blas::Uplo::Lower) ? ptrs[ell+1] - 1 : ptrs[ell];
+            randblas_require(idxs[p] == ell);
+            randblas_require(unitdiag || vals[p] != 0.0);
+        }
+    } else {
+        const sint_t* ptrs = A.colptr;
+        const sint_t* idxs = A.rowidxs;
+        if (mode >= 0) {
+            bool ordered_indices = compressed_indices_are_increasing(m, ptrs, idxs, &flag);
+            if (!ordered_indices) {
+                std::stringstream ss;
+                ss << "Ill-formed CSC matrix; indices in column " << flag << " are not sorted.";
+                throw RandBLAS::Error(ss.str());
+            }
+        }
+        for (ell = 0; ell < m; ++ell) {
+            p = (uplo == blas::Uplo::Lower) ? ptrs[ell] : ptrs[ell+1] - 1;
+            randblas_require(idxs[p] == ell);
+            randblas_require(unitdiag || vals[p] != 0.0);
+        }
+    }
+    return;
+}
+
+
+// =============================================================================
+/// \fn trsm(
+///     blas::Layout layout, blas::Op opA, T alpha, const SpMat &A, blas::Uplo uplo, blas::Diag diag, int64_t n, T *B, int64_t ldb, int validation_mode = 1
+/// )
+/// @verbatim embed:rst:leading-slashes
+/// Overwrite :math:`n` columns of a matrix :math:`\mat(B)` with the results of a scaled triangular solve
+///
+/// .. math::
+///     \mat(B) = \alpha \cdot \underbrace{\op(\mtxA)^{-1}}_{m \times m} \cdot \underbrace{\mat(B)}_{m \times n},   \tag{$\star$}
+///
+/// where :math:`\mtxA` is either the sparse matrix :math:`A` or a view of :math:`A` that replaces
+/// its diagonal with the vector of all ones, and :math:`\op(\mtxA)` returns either :math:`\mtxA` or :math:`\mtxA^T.`
+///
+/// .. dropdown:: Full parameter descriptions
+///     :animate: fade-in-slide-down
+///
+///      layout - [in]
+///       * Layout::ColMajor or Layout::RowMajor.
+///       * Matrix storage for :math:`\mat(B).`
+///
+///      opA - [in]
+///       * If :math:`\opA` = NoTrans, then :math:`\op(\mtxA) = \mtxA.`
+///       * If :math:`\opA` = Trans, then :math:`\op(\mtxA) = \mtxA^T.`
+///
+///      alpha - [in]
+///       * A real scalar.
+///
+///      A - [in]
+///       * A RandBLAS CSCMatrix or CSRMatrix.
+///       * Considered along with :math:`\texttt{diag}` to define :math:`\mtxA.`
+///
+///      uplo - [in]
+///       * Promises that :math:`A` is structurally upper triangular (if :math:`\texttt{uplo = Uplo::Upper}`) or
+///         structurally lower triangular (if :math:`\texttt{uplo = Uplo::Lower}`). Violating this promise will 
+///         result in an error if :math:`\texttt{validation_mode} \geq 1` or undefined behavior if 
+///         :math:`\texttt{validation_mode} \leq 0.`
+///       * Future RandBLAS versions may change behavior so that :math:`\mtxA` is defined as a view of the
+///         :math:`\texttt{uplo}` part of :math:`A,` with its diagonal possibly redefined as the vector of 
+///         all ones according to :math:`\texttt{diag}.`
+///
+///      diag - [in]
+///       * Diag::Unit or Diag::NonUnit.
+///       * If NonUnit, then :math:`\mtxA = A` and the triangular solve is performed as usual.
+///       * If Unit, then :math:`\mtxA` is an implicit copy of :math:`A` with its diagonal overwritten to contain all ones.
+///
+///      n - [in]
+///       * A nonnegative integer.
+///       * The number of columns in :math:`\mat(B).`
+///
+///      B - [in, out]
+///       * Pointer to 1D array of real scalars that define :math:`\mat(B).`
+///
+///      ldb - [in]
+///       * A nonnegative integer.
+///       * The leading dimension of :math:`\mat(B)` when reading from :math:`B.`
+///
+///      validation_mode - [in]
+///       * A flag used to indicate what checks should be made for validity of :math:`(A,\texttt{diag},\texttt{uplo}).`
+///       * If positive, then all checks will be made to ensure that we can correctly apply :math:`\op(\mtxA)^{-1}` to vectors;
+///         these checks take :math:`O(A\texttt{.nnz})` time.
+///       * If zero, then only checks of cost :math:`O(A\texttt{.n_rows})` are performed.
+///       * If negative, then only checks of cost :math:`O(1)` are performed.
+///       * The specific default value of this optional argument may change in future releases of RandBLAS.
+///
+/// @endverbatim
+template <SparseMatrix SpMat, typename T = SpMat::scalar_t>
+void trsm(
+    blas::Layout layout, blas::Op opA, T alpha, const SpMat &A, blas::Uplo uplo, blas::Diag diag, int64_t n, T *B, int64_t ldb,
+    int validation_mode = 1
+) {
+    using blas::Op;
+    using blas::Uplo;
+
+    if (opA == Op::Trans) {
+        using sint_t = typename SpMat::index_t;
+        constexpr bool is_csc = std::is_same_v<SpMat, CSCMatrix<T, sint_t>>;
+        constexpr bool is_csr = std::is_same_v<SpMat, CSRMatrix<T, sint_t>>;
+        auto trans_uplo = (uplo == Uplo::Lower) ? Uplo::Upper : Uplo::Lower;
+        if constexpr (is_csc) {
+            auto At = RandBLAS::sparse_data::conversions::transpose_as_csr(A);
+            trsm(layout, Op::NoTrans, alpha, At, trans_uplo, diag, n, B, ldb);
+        } else if constexpr (is_csr) {
+            auto At = RandBLAS::sparse_data::conversions::transpose_as_csc(A);
+            trsm(layout, Op::NoTrans, alpha, At, trans_uplo, diag, n, B, ldb);
+        } else {
+            randblas_require(false);
+        }
+        return; 
+    }
+
+    randblas_require( A.n_rows == A.n_cols );
+    randblas_require( A.index_base == IndexBase::Zero );
+
+    using sint_t = typename SpMat::index_t;
+    constexpr bool is_csr = std::is_same_v<SpMat, CSRMatrix<T, sint_t>>;
+    constexpr bool is_csc = std::is_same_v<SpMat, CSCMatrix<T, sint_t>>;
+    randblas_require(is_csr || is_csc);
+
+    if (validation_mode >= 0) trsm_matrix_validation( A, uplo, diag, validation_mode - 1 );
+
+    int64_t m = A.n_rows;
+    if (layout == blas::Layout::ColMajor) {
+        randblas_require(ldb >= m);
+        for (int64_t i = 0; i < n; ++i)
+            RandBLAS::util::safe_scal(m, alpha, &B[i*ldb], 1);
+    } else {
+        randblas_require(ldb >= n);
+        for (int64_t i = 0; i < m; ++i)
+            RandBLAS::util::safe_scal(n, alpha, &B[i*ldb], 1);
+    }
+
+    if (alpha == static_cast<T>(0))
+        return;
+
+    if constexpr (is_csr) {
+        sparse_data::csr::trsm_jki_p11(layout, uplo, diag, n, A, B, ldb);
+    } else {
+        sparse_data::csc::trsm_jki_p11(layout, uplo, diag, n, A, B, ldb);
+    }
+    return;
+}
+
+} // end namespace RandBLAS::sparse_data

--- a/rtd/source/api_reference/sketch_sparse.rst
+++ b/rtd/source/api_reference/sketch_sparse.rst
@@ -106,3 +106,10 @@ Deterministic operations
 
     .. doxygenfunction:: RandBLAS::spmm(blas::Layout layout, blas::Op opA, blas::Op opB, int64_t m, int64_t n, int64_t k, T alpha, const T* A, int64_t lda, SpMat &B, T beta, T *C, int64_t ldc) 
       :project: RandBLAS
+
+.. dropdown:: :math:`\mtxB = \alpha \cdot \op(\mtxA)^{-1} \cdot \mtxB,` with sparse triangular :math:`\mtxA`
+    :animate: fade-in-slide-down
+    :color: light
+
+    .. doxygenfunction:: RandBLAS::sparse_data::trsm(blas::Layout layout, blas::Op opA, T alpha, const SpMat &A, blas::Uplo uplo, blas::Diag diag, int64_t n, T *B, int64_t ldb, int validation_mode = 1)
+      :project: RandBLAS

--- a/test/test_sparse_trsm/test_sparse_trsm.cc
+++ b/test/test_sparse_trsm/test_sparse_trsm.cc
@@ -5,11 +5,16 @@
 #include <RandBLAS/random_gen.hh>
 #include <RandBLAS/exceptions.hh>
 #include <RandBLAS/sparse_skops.hh>
+#include <RandBLAS/sparse_data/trsm_dispatch.hh>
 #include <RandBLAS/sparse_data/csr_trsm_impl.hh>
 #include <RandBLAS/sparse_data/csc_trsm_impl.hh>
 using RandBLAS::sparse_data::CSRMatrix;
 using RandBLAS::sparse_data::CSCMatrix;
 using RandBLAS::sparse_data::COOMatrix;
+using blas::Layout;
+using blas::Uplo;
+using blas::Op;
+using blas::Diag;
 #include "../comparison.hh"
 #include "../test_datastructures/test_spmats/common.hh"
 
@@ -39,8 +44,8 @@ class TestSptrsm : public ::testing::Test
         COOMatrix<T> A(n, n);
         std::vector<T> actual(n * n);
         RandBLAS::RNGState s(key);
-        test::test_datastructures::test_spmats::iid_sparsify_random_dense<T>(n, n, blas::Layout::ColMajor, actual.data(), 1 - nonzero_prob, s);
-        RandBLAS::sparse_data::coo::dense_to_coo<T>(blas::Layout::ColMajor, actual.data(), 0.0, A);
+        test::test_datastructures::test_spmats::iid_sparsify_random_dense<T>(n, n, Layout::ColMajor, actual.data(), 1 - nonzero_prob, s);
+        RandBLAS::sparse_data::coo::dense_to_coo<T>(Layout::ColMajor, actual.data(), 0.0, A);
 
         COOMatrix<T> A_triangular(n, n);
         test::test_datastructures::test_spmats::trianglize_coo<T>(A, upper, A_triangular);
@@ -62,14 +67,14 @@ class TestSptrsm : public ::testing::Test
             rhs_ptr[i] = i;
         }
         if (upper) {
-            RandBLAS::sparse_data::csr::upper_trsv(A.vals, A.rowptr, A.colidxs, n, rhs_ptr, incx);
+            RandBLAS::sparse_data::csr::upper_trsv(true, A.vals, A.rowptr, A.colidxs, n, rhs_ptr, incx);
         } else {
-            RandBLAS::sparse_data::csr::lower_trsv(A.vals, A.rowptr, A.colidxs, n, rhs_ptr, incx);
+            RandBLAS::sparse_data::csr::lower_trsv(true, A.vals, A.rowptr, A.colidxs, n, rhs_ptr, incx);
         }
 
         std::vector<T> reference(n);
-        T* ref_ptr =reference.data();
-        RandBLAS::spmm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, n, 1, n, 1.0, A, rhs_ptr, incx, 0.0, ref_ptr, 1);
+        T* ref_ptr = reference.data();
+        RandBLAS::spmm(Layout::RowMajor, Op::NoTrans, Op::NoTrans, n, 1, n, 1.0, A, rhs_ptr, incx, 0.0, ref_ptr, 1);
         
         for (int64_t i = 0; i < n; ++i) {
             randblas_require(std::abs(ref_ptr[i] - incx * i) <= RandBLAS::sqrt_epsilon<T>());
@@ -88,14 +93,14 @@ class TestSptrsm : public ::testing::Test
             rhs_ptr[i] = i;
         }
         if (upper) {
-            RandBLAS::sparse_data::csc::upper_trsv(A.vals, A.rowidxs, A.colptr, n, rhs_ptr, incx);
+            RandBLAS::sparse_data::csc::upper_trsv(true, A.vals, A.rowidxs, A.colptr, n, rhs_ptr, incx);
         } else {
-            RandBLAS::sparse_data::csc::lower_trsv(A.vals, A.rowidxs, A.colptr, n, rhs_ptr, incx);
+            RandBLAS::sparse_data::csc::lower_trsv(true, A.vals, A.rowidxs, A.colptr, n, rhs_ptr, incx);
         }
 
         std::vector<T> reference(n);
         T* ref_ptr =reference.data();
-        RandBLAS::spmm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, n, 1, n, 1.0, A, rhs_ptr,incx, 0.0, ref_ptr, 1);
+        RandBLAS::spmm(Layout::RowMajor, Op::NoTrans, Op::NoTrans, n, 1, n, 1.0, A, rhs_ptr,incx, 0.0, ref_ptr, 1);
         
         for (int64_t i = 0; i < n; ++i) {
             randblas_require(std::abs(ref_ptr[i] - incx * i) <= RandBLAS::sqrt_epsilon<T>());
@@ -104,62 +109,62 @@ class TestSptrsm : public ::testing::Test
     }
 
     template<typename T>
-    static void test_csc_solve_matrix(int64_t n, T p, bool upper, int64_t k, uint32_t key) {
-        auto A_coo = make_test_matrix(n, p, upper, key);
+    static void test_csc_solve_matrix(Layout layout, int64_t n, T p, Op op,  Uplo uplo, int64_t k, uint32_t key) {
+        auto A_coo = make_test_matrix(n, p, uplo == Uplo::Upper, key);
         CSCMatrix<T> A(n, n);
         RandBLAS::sparse_data::conversions::coo_to_csc(A_coo, A);
         std::vector<T> rhs(k * n);
         T* rhs_ptr = rhs.data();
-        for (int64_t i=0; i < k * n; i++) {
+        for (int64_t i = 0; i < k * n; i++) {
             rhs_ptr[i] = i;
         }
-        if (upper) {
-            RandBLAS::sparse_data::csc::trsm_jki_p11(blas::Layout::RowMajor, blas::Uplo::Upper, n, k, A, rhs_ptr, k); 
-        } else {
-            RandBLAS::sparse_data::csc::trsm_jki_p11(blas::Layout::RowMajor, blas::Uplo::Lower, n, k, A, rhs_ptr, k); 
-        }
+        std::vector<T> rhs_copy(rhs);
+        int64_t ldb = (layout == Layout::RowMajor) ? k : n;
+        RandBLAS::sparse_data::trsm(layout, op, (T)1.0, A, uplo, Diag::NonUnit, k, rhs_ptr, ldb);
 
         std::vector<T> reference(k * n);
-        T* ref_ptr =reference.data();
-        RandBLAS::spmm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, n, k, n, 1.0, A, rhs_ptr, k, 0.0, ref_ptr, k);
+        T* ref_ptr = reference.data();
+        RandBLAS::spmm(layout, op, Op::NoTrans, n, k, n, 1.0, A, rhs_ptr, ldb, 0.0, ref_ptr, ldb);
         
-        for (int64_t i = 0; i < k * n; ++i) {
-	    std::cout << ref_ptr[i] << "\t" << i << std::endl;
-            randblas_require(std::abs(ref_ptr[i] - i) <= RandBLAS::sqrt_epsilon<T>());
-        }
+        T atol = RandBLAS::sqrt_epsilon<T>();
+        T rtol = atol;
+        test::comparison::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol);
         return;
     }
 
-
     template<typename T>
-    static void test_csr_solve_matrix(int64_t n, T p, bool upper, int64_t k, uint32_t key) {
-        auto A_coo = make_test_matrix(n, p, upper, key);
+    static void test_csr_solve_matrix(Layout layout, int64_t n, T p, Op op, Uplo uplo, int64_t k, uint32_t key) {
+        auto A_coo = make_test_matrix(n, p, uplo == Uplo::Upper, key);
         CSRMatrix<T> A(n, n);
         RandBLAS::sparse_data::conversions::coo_to_csr(A_coo, A);
         std::vector<T> rhs(k * n);
         T* rhs_ptr = rhs.data();
-        for (int64_t i=0; i < k * n; i++) {
+        for (int64_t i= 0; i < k * n; i++) {
             rhs_ptr[i] = i;
         }
-        if (upper) {
-            RandBLAS::sparse_data::csr::trsm_jki_p11(blas::Layout::RowMajor, blas::Uplo::Upper, n, k, A, rhs_ptr, k); 
-        } else {
-            RandBLAS::sparse_data::csr::trsm_jki_p11(blas::Layout::RowMajor, blas::Uplo::Lower, n, k, A, rhs_ptr, k); 
-        }
+        std::vector<T> rhs_copy(rhs);
+        int64_t ldb = (layout == Layout::RowMajor) ? k : n;
+        RandBLAS::sparse_data::trsm(layout, op, (T)1.0, A, uplo, Diag::NonUnit, k, rhs_ptr, ldb);
 
         std::vector<T> reference(k * n);
-        T* ref_ptr =reference.data();
-        RandBLAS::spmm(blas::Layout::RowMajor, blas::Op::NoTrans, blas::Op::NoTrans, n, k, n, 1.0, A, rhs_ptr, k, 0.0, ref_ptr, k);
+        T* ref_ptr = reference.data();
+        RandBLAS::spmm(layout, op, Op::NoTrans, n, k, n, 1.0, A, rhs_ptr, ldb, 0.0, ref_ptr, ldb);
         
-        for (int64_t i = 0; i < k * n; ++i) {
-	    std::cout << ref_ptr[i] << "\t" << i << std::endl;
-            randblas_require(std::abs(ref_ptr[i] - i) <= RandBLAS::sqrt_epsilon<T>());
-        }
+        // for (int64_t i = 0; i < k * n; ++i) {
+	    //     std::cout << ref_ptr[i] << "\t" << i << std::endl;
+        //     randblas_require(std::abs(ref_ptr[i] - i) <= RandBLAS::sqrt_epsilon<T>());
+        // }
+        T atol = RandBLAS::sqrt_epsilon<T>();
+        T rtol = atol;
+        test::comparison::buffs_approx_equal(k*n, rhs_copy.data(), 1, ref_ptr, 1, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol);
         return;
     }
 
 
 };
+
+
+// MARK: TRSV
 
 TEST_F(TestSptrsm, upper_csr_solve) {
     test_csr_solve(1, 1.0, true, 3, 0x364A);
@@ -170,7 +175,6 @@ TEST_F(TestSptrsm, upper_csr_solve) {
     test_csr_solve(2, 0.5, true, 1, 0x3643);
     test_csr_solve(5, 0.9999, true, 1, 0x219B);
 }
-
 
 TEST_F(TestSptrsm, lower_csr_solve) {
     test_csr_solve(1, 1.0, false, 3, 0x364A);
@@ -192,7 +196,6 @@ TEST_F(TestSptrsm, upper_csc_solve) {
     test_csc_solve(5, 0.9999, true, 1, 0x219B);
 }
 
-
 TEST_F(TestSptrsm, lower_csc_solve) {
     test_csc_solve(1, 1.0, false, 3, 0x364A);
     test_csc_solve(2, 0.5, false, 3, 0x3643);
@@ -203,42 +206,168 @@ TEST_F(TestSptrsm, lower_csc_solve) {
     test_csc_solve(5, 0.9999, false, 1, 0x219B);
 }
 
-TEST_F(TestSptrsm, lower_csc_solve_matrix) {
-    test_csc_solve_matrix(1, 1.0, false, 1, 0x364A);
-    test_csc_solve_matrix(2, 0.5, false, 1, 0x3643);
-    test_csc_solve_matrix(5, 0.9999, false, 1, 0x219B);
 
-    test_csc_solve_matrix(1, 1.0, false, 3, 0x364A);
-    test_csc_solve_matrix(2, 0.5, false, 3, 0x3643);
-    test_csc_solve_matrix(5, 0.9999, false, 3, 0x219B);
+// MARK: TRSM, row major
+
+TEST_F(TestSptrsm, lower_csc_solve_matrix_rowmajor) {
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 1, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 1, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 1, 0x219B);
+
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 3, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 3, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 3, 0x219B);
 }
 
-TEST_F(TestSptrsm, upper_csc_solve_matrix) {
-    test_csc_solve_matrix(1, 1.0, true, 1, 0x364A);
-    test_csc_solve_matrix(2, 0.5, true, 1, 0x3643);
-    test_csc_solve_matrix(5, 0.9999, true, 1, 0x219B);
+TEST_F(TestSptrsm, upper_csc_solve_matrix_rowmajor) {
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 1, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 1, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 1, 0x219B);
 
-    test_csc_solve_matrix(1, 1.0, true, 3, 0x364A);
-    test_csc_solve_matrix(2, 0.5, true, 3, 0x3643);
-    test_csc_solve_matrix(5, 0.9999, true, 3, 0x219B);
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 3, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 3, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 3, 0x219B);
 }
 
-TEST_F(TestSptrsm, lower_csr_solve_matrix) {
-    test_csr_solve_matrix(1, 1.0, false, 1, 0x364A);
-    test_csr_solve_matrix(2, 0.5, false, 1, 0x3643);
-    test_csr_solve_matrix(5, 0.9999, false, 1, 0x219B);
+TEST_F(TestSptrsm, lower_csr_solve_matrix_rowmajor) {
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 1, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 1, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 1, 0x219B);
 
-    test_csr_solve_matrix(1, 1.0, false, 3, 0x364A);
-    test_csr_solve_matrix(2, 0.5, false, 3, 0x3643);
-    test_csr_solve_matrix(5, 0.9999, false, 3, 0x219B);
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 3, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 3, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 3, 0x219B);
 }
 
-TEST_F(TestSptrsm, upper_csr_solve_matrix) {
-    test_csr_solve_matrix(1, 1.0, true, 1, 0x364A);
-    test_csr_solve_matrix(2, 0.5, true, 1, 0x3643);
-    test_csr_solve_matrix(5, 0.9999, true, 1, 0x219B);
+TEST_F(TestSptrsm, upper_csr_solve_matrix_rowmajor) {
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 1, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 1, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 1, 0x219B);
 
-    test_csr_solve_matrix(1, 1.0, true, 3, 0x364A);
-    test_csr_solve_matrix(2, 0.5, true, 3, 0x3643);
-    test_csr_solve_matrix(5, 0.9999, true, 3, 0x219B);
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 3, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 3, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, lower_csc_trans_solve_matrix_rowmajor) {
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 1, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 1, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 1, 0x219B);
+
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 3, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 3, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, upper_csc_trans_solve_matrix_rowmajor) {
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 1, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 1, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 1, 0x219B);
+
+    test_csc_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 3, 0x364A);
+    test_csc_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 3, 0x3643);
+    test_csc_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, lower_csr_trans_solve_matrix_rowmajor) {
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 1, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 1, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 1, 0x219B);
+
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 3, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 3, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, upper_csr_trans_solve_matrix_rowmajor) {
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 1, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 1, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 1, 0x219B);
+
+    test_csr_solve_matrix(Layout::RowMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 3, 0x364A);
+    test_csr_solve_matrix(Layout::RowMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 3, 0x3643);
+    test_csr_solve_matrix(Layout::RowMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 3, 0x219B);
+}
+
+// MARK: TRSM, column major
+
+
+TEST_F(TestSptrsm, lower_csc_solve_matrix_comajor) {
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 1, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 1, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 1, 0x219B);
+
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 3, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 3, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, upper_csc_solve_matrix_comajor) {
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 1, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 1, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 1, 0x219B);
+
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 3, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 3, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, lower_csr_solve_matrix_comajor) {
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 1, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 1, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 1, 0x219B);
+
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Lower, 3, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Lower, 3, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Lower, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, upper_csr_solve_matrix_comajor) {
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 1, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 1, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 1, 0x219B);
+
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::NoTrans, Uplo::Upper, 3, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::NoTrans, Uplo::Upper, 3, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::NoTrans, Uplo::Upper, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, lower_csc_trans_solve_matrix_comajor) {
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 1, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 1, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 1, 0x219B);
+
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 3, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 3, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, upper_csc_trans_solve_matrix_comajor) {
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 1, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 1, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 1, 0x219B);
+
+    test_csc_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 3, 0x364A);
+    test_csc_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 3, 0x3643);
+    test_csc_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, lower_csr_trans_solve_matrix_comajor) {
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 1, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 1, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 1, 0x219B);
+
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Lower, 3, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Lower, 3, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Lower, 3, 0x219B);
+}
+
+TEST_F(TestSptrsm, upper_csr_trans_solve_matrix_comajor) {
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 1, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 1, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 1, 0x219B);
+
+    test_csr_solve_matrix(Layout::ColMajor, 1, 1.0,    Op::Trans, Uplo::Upper, 3, 0x364A);
+    test_csr_solve_matrix(Layout::ColMajor, 2, 0.5,    Op::Trans, Uplo::Upper, 3, 0x3643);
+    test_csr_solve_matrix(Layout::ColMajor, 5, 0.9999, Op::Trans, Uplo::Upper, 3, 0x219B);
 }


### PR DESCRIPTION
@PTNobel did fantastic work at the AMD Tools workshop on adding sparse trsm kernels to RandBLAS. This PR exposes those kernels to RandBLAS' public API. Note that these changes won't appear on the RandBLAS website until the release of RandBLAS 1.1.

Changes
* Create a file, sparse_data/trsm_dispatch.hh, which contains two new functions to the RandBLAS::sparse_data namespace: trsm_matrix_validation and trsm. Only the latter of these functions appears on our web docs.
* Add a utility function, ``compressed_indices_are_increasing``, to sparse_data/base.hh for use in checking assumptions in the new sparse trsm function.
* Add ``diag`` flags to sparse trsm kernels and ``nonunit`` flags to sparse trsv kernels. Remove redundant dimensional arguments from these kernels. In TRSM, change the variable used to refer to the number of right-hand-sides from "k" to "n" (and change the square matrix dimension from "n" to "m").
* Updated sparse TRSM tests to use the new public-API sparse_data::trsm function rather than private implementation functions. Add tests for the transposition flag and different layouts in sparse_data::trsm.

Incidental changes
* Add ``const`` qualifiers in sparse matrix format conversion functions.
* Fix minor documentation mistakes (arising from copy-pasting ...) in sparse_data/csc_matrix.hh.